### PR TITLE
Fix checking for PACE requirements

### DIFF
--- a/htd_validate/decompositions/ghtd.py
+++ b/htd_validate/decompositions/ghtd.py
@@ -98,12 +98,6 @@ class GeneralizedHypertreeDecomposition(Decomposition):
                 'Too many mappings. Found %s expected %s \n' % (
                     len(decomp.hyperedge_function), header['num_bags']))
             exit(2)
-        for b in decomp.bags.iterkeys():
-            for e in xrange(1, header['num_hyperedges'] + 1):
-                if not decomp.hyperedge_function[b].has_key(e):
-                    logging.error(
-                        'Missing function mapping for node %s of the tree. Missing for edge %s \n' % (b, e))
-                    exit(2)
         if header['max_function_value'] != decomp.width():
             logging.error(
                 'Given width is wrong. Computed width %s, given width %s \n' % (

--- a/htd_validate/utils/hypergraph.py
+++ b/htd_validate/utils/hypergraph.py
@@ -648,7 +648,7 @@ class Hypergraph(object):
             if not line:
                 continue
             elif line[0] == 'p':
-                is_dimacs = line[1] == 'edge'
+                is_dimacs = line[1] == 'edge' or "htd" in line[1]
             elif line[0] != 'c':
                 if is_dimacs:
                     HG.add_hyperedge(map(int, line[1:]))


### PR DESCRIPTION
- Remove that edge function must be written, since if it is not written it will be assumed as 0
- Ensure the line read for hyperedge is `edge_num v1 v2 ... vx`, instead of `v1 v2 ... vx`. Kinda hacky though..